### PR TITLE
Use: Immutable.js

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -13,7 +13,6 @@
   "rules": {
     "eqeqeq": 2,
     "guard-for-in": 2,
-    "new-cap": 2,
     "no-caller": 2,
     "no-console": 2,
     "no-extend-native": 2,

--- a/package.json
+++ b/package.json
@@ -19,15 +19,17 @@
   "dependencies": {
     "express": "^4.14.0",
     "express-session": "^1.14.1",
+    "immutable": "^4.0.0-rc.12",
     "morgan": "^1.5.1",
-    "prop-types": "^15.5.10",
     "react": "^16.2.0",
     "react-dom": "^16.2.0",
     "react-helmet": "^5.2.0",
+    "react-immutable-proptypes": "^2.1.0",
     "react-redux": "^5.0.6",
     "react-router": "^4.2.0",
     "react-router-dom": "^4.2.2",
     "redux": "^3.7.2",
+    "redux-immutable": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
     "serve-favicon": "^2.2.0"

--- a/src/react/client-mount.jsx
+++ b/src/react/client-mount.jsx
@@ -1,8 +1,10 @@
+import { fromJS } from 'immutable';
 import React from 'react';
 import ReactDOM from 'react-dom';
 import { Provider } from 'react-redux';
 import { BrowserRouter } from 'react-router-dom'
-import { applyMiddleware, createStore, combineReducers } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
+import { combineReducers } from 'redux-immutable';
 import { createLogger } from 'redux-logger';
 import thunkMiddleware from 'redux-thunk';
 
@@ -13,11 +15,11 @@ window.onload = () => {
 
 	const preloadedState = JSON.parse(document.getElementById('react-client-data').innerText);
 
-	const loggerMiddleware = createLogger();
+	const loggerMiddleware = createLogger({ stateTransformer: state => state.toJS() });
 
 	const store = createStore(
 		combineReducers(reducers),
-		preloadedState,
+		fromJS(preloadedState),
 		applyMiddleware(...[thunkMiddleware, loggerMiddleware])
 	);
 

--- a/src/react/components/instance-document-title.jsx
+++ b/src/react/components/instance-document-title.jsx
@@ -3,7 +3,10 @@ import { Helmet } from 'react-helmet';
 
 const DocumentTitle = props => {
 
-	const { instance: { name, model } } = props;
+	const { instance } = props;
+
+	const name = instance.get('name');
+	const model = instance.get('model');
 
 	return (
 		name !== undefined && model !== undefined

--- a/src/react/components/instance-link.jsx
+++ b/src/react/components/instance-link.jsx
@@ -7,13 +7,13 @@ const InstanceLink = props => {
 
 	const { instance, index } = props;
 
-	const { model, uuid } = instance;
+	const model = instance.get('model');
 
-	const instanceRoute = `/${irregularPluralNouns[model] || model + 's'}/${uuid}`;
+	const instanceRoute = `/${irregularPluralNouns[model] || model + 's'}/${instance.get('uuid')}`;
 
 	return (
 		<Link key={index || null} to={instanceRoute}>
-			{instance.name}
+			{instance.get('name')}
 		</Link>
 	);
 

--- a/src/react/components/joined-roles.jsx
+++ b/src/react/components/joined-roles.jsx
@@ -1,3 +1,4 @@
+import { Map } from 'immutable';
 import React from 'react';
 
 import InstanceLink from './instance-link';
@@ -11,9 +12,9 @@ const JoinedArray = props => {
 			{
 				instances
 					.map((instance, index) =>
-						instance.model && instance.uuid
+						Map.isMap(instance) && instance.get('model') && instance.get('uuid')
 							? <InstanceLink key={index} index={index} instance={instance}/>
-							: <span key={index}>{instance.name || instance}</span>
+							: <span key={index}>{Map.isMap(instance) ? instance.get('name') : instance}</span>
 					)
 					.reduce((prev, curr) => [prev, ' / ', curr])
 			}

--- a/src/react/components/list.jsx
+++ b/src/react/components/list.jsx
@@ -14,13 +14,13 @@ const List = props => {
 						<InstanceLink instance={instance}/>
 
 						{
-							instance.theatre
+							instance.get('theatre')
 								? (
 									<span>
 
 										&nbsp;-&nbsp;
 
-										<InstanceLink instance={instance.theatre}/>
+										<InstanceLink instance={instance.get('theatre')}/>
 
 									</span>
 								)
@@ -28,7 +28,7 @@ const List = props => {
 						}
 
 						{
-							instance.roles && instance.roles.length
+							instance.get('roles') && instance.get('roles').size
 								? (
 									<span>
 
@@ -36,7 +36,7 @@ const List = props => {
 
 										<span className="role-text">
 
-											<JoinedRoles instances={instance.roles}/>
+											<JoinedRoles instances={instance.get('roles')}/>
 
 										</span>
 
@@ -46,14 +46,14 @@ const List = props => {
 						}
 
 						{
-							instance.performers && instance.performers.length
+							instance.get('performers') && instance.get('performers').size
 								? (
 									<span>
 
 										&nbsp;- performed by:&nbsp;
 
 										{
-											instance.performers
+											instance.get('performers')
 												.map((performer, index) =>
 													<span key={index}>
 
@@ -63,18 +63,18 @@ const List = props => {
 
 															&nbsp;…&nbsp;
 
-															<span className="role-text">{performer.role.name}</span>
+															<span className="role-text">{performer.getIn(['role', 'name'])}</span>
 
 														</span>
 
 														{
-															performer.otherRoles.length
+															performer.get('otherRoles').size
 																? (
 																	<span>; also performed:&nbsp;
 
 																		<span className="role-text">
 
-																			<JoinedRoles instances={performer.otherRoles}/>
+																			<JoinedRoles instances={performer.get('otherRoles')}/>
 
 																		</span>
 

--- a/src/react/components/related-instance.jsx
+++ b/src/react/components/related-instance.jsx
@@ -1,3 +1,4 @@
+import { List as ImmutableList } from 'immutable';
 import React from 'react';
 
 import InstanceLink from './instance-link';
@@ -17,7 +18,7 @@ const RelatedInstance = props => {
 
 			<div className="content">
 				{
-					Array.isArray(instance)
+					ImmutableList.isList(instance)
 						? join
 							? <JoinedRoles instances={instance}/>
 							: <List instances={instance}/>

--- a/src/react/pages/instances/character.jsx
+++ b/src/react/pages/instances/character.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import RelatedInstance from '../../components/related-instance';
@@ -11,25 +11,27 @@ class Character extends React.Component {
 
 		const { character } = this.props;
 
-		const { playtexts, variantNames, productions } = character;
+		const playtexts = character.get('playtexts');
+		const variantNames = character.get('variantNames');
+		const productions = character.get('productions');
 
 		return (
 			<InstanceWrapper instance={character}>
 
 				{
-					playtexts && playtexts.length
+					playtexts && playtexts.size
 						? <RelatedInstance labelText='Playtexts' instance={playtexts}/>
 						: null
 				}
 
 				{
-					variantNames && variantNames.length
+					variantNames && variantNames.size
 						? <RelatedInstance labelText='Variant names' instance={variantNames} join/>
 						: null
 				}
 
 				{
-					productions && productions.length
+					productions && productions.size
 						? <RelatedInstance labelText='Productions' instance={productions}/>
 						: null
 				}
@@ -41,8 +43,8 @@ class Character extends React.Component {
 
 };
 
-Character.propTypes = { character: PropTypes.object.isRequired };
+Character.propTypes = { character: ImmutablePropTypes.map.isRequired };
 
-const mapStateToProps = ({ character }) => ({ character });
+const mapStateToProps = state => ({ character: state.get('character') });
 
 export default connect(mapStateToProps)(Character);

--- a/src/react/pages/instances/person.jsx
+++ b/src/react/pages/instances/person.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import RelatedInstance from '../../components/related-instance';
@@ -11,13 +11,13 @@ class Person extends React.Component {
 
 		const { person } = this.props;
 
-		const { productions } = person;
+		const productions = person.get('productions');
 
 		return (
 			<InstanceWrapper instance={person}>
 
 				{
-					productions && productions.length
+					productions && productions.size
 						? <RelatedInstance labelText='Productions' instance={productions}/>
 						: null
 				}
@@ -29,8 +29,8 @@ class Person extends React.Component {
 
 };
 
-Person.propTypes = { person: PropTypes.object.isRequired };
+Person.propTypes = { person: ImmutablePropTypes.map.isRequired };
 
-const mapStateToProps = ({ person }) => ({ person });
+const mapStateToProps = state => ({ person: state.get('person') });
 
 export default connect(mapStateToProps)(Person);

--- a/src/react/pages/instances/playtext.jsx
+++ b/src/react/pages/instances/playtext.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import RelatedInstance from '../../components/related-instance';
@@ -11,19 +11,20 @@ class Playtext extends React.Component {
 
 		const { playtext } = this.props;
 
-		const { productions, characters } = playtext;
+		const productions = playtext.get('productions');
+		const characters = playtext.get('characters');
 
 		return (
 			<InstanceWrapper instance={playtext}>
 
 				{
-					productions && productions.length
+					productions && productions.size
 						? <RelatedInstance labelText='Productions' instance={productions}/>
 						: null
 				}
 
 				{
-					characters && characters.length
+					characters && characters.size
 						? <RelatedInstance labelText='Characters' instance={characters}/>
 						: null
 				}
@@ -35,8 +36,8 @@ class Playtext extends React.Component {
 
 };
 
-Playtext.propTypes = { playtext: PropTypes.object.isRequired };
+Playtext.propTypes = { playtext: ImmutablePropTypes.map.isRequired };
 
-const mapStateToProps = ({ playtext }) => ({ playtext });
+const mapStateToProps = state => ({ playtext: state.get('playtext') });
 
 export default connect(mapStateToProps)(Playtext);

--- a/src/react/pages/instances/production.jsx
+++ b/src/react/pages/instances/production.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import RelatedInstance from '../../components/related-instance';
@@ -11,7 +11,9 @@ class Production extends React.Component {
 
 		const { production } = this.props;
 
-		const { theatre, playtext, cast } = production;
+		const theatre = production.get('theatre');
+		const playtext = production.get('playtext');
+		const cast = production.get('cast');
 
 		return (
 			<InstanceWrapper instance={production}>
@@ -29,7 +31,7 @@ class Production extends React.Component {
 				}
 
 				{
-					cast && cast.length
+					cast && cast.size
 						? <RelatedInstance labelText='Cast' instance={cast}/>
 						: null
 				}
@@ -41,8 +43,8 @@ class Production extends React.Component {
 
 };
 
-Production.propTypes = { production: PropTypes.object.isRequired };
+Production.propTypes = { production: ImmutablePropTypes.map.isRequired };
 
-const mapStateToProps = ({ production }) => ({ production });
+const mapStateToProps = state => ({ production: state.get('production') });
 
 export default connect(mapStateToProps)(Production);

--- a/src/react/pages/instances/theatre.jsx
+++ b/src/react/pages/instances/theatre.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import RelatedInstance from '../../components/related-instance';
@@ -11,13 +11,13 @@ class Theatre extends React.Component {
 
 		const { theatre } = this.props;
 
-		const { productions } = theatre;
+		const productions = theatre.get('productions');
 
 		return (
 			<InstanceWrapper instance={theatre}>
 
 				{
-					productions && productions.length
+					productions && productions.size
 						? <RelatedInstance labelText='Productions' instance={productions}/>
 						: null
 				}
@@ -29,8 +29,8 @@ class Theatre extends React.Component {
 
 };
 
-Theatre.propTypes = { theatre: PropTypes.object.isRequired };
+Theatre.propTypes = { theatre: ImmutablePropTypes.map.isRequired };
 
-const mapStateToProps = ({ theatre }) => ({ theatre });
+const mapStateToProps = state => ({ theatre: state.get('theatre') });
 
 export default connect(mapStateToProps)(Theatre);

--- a/src/react/pages/lists/characters.jsx
+++ b/src/react/pages/lists/characters.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import ListWrapper from '../../utils/list-wrapper';
@@ -20,8 +20,8 @@ class Characters extends React.Component {
 
 };
 
-Characters.propTypes = { characters: PropTypes.array.isRequired };
+Characters.propTypes = { characters: ImmutablePropTypes.list.isRequired };
 
-const mapStateToProps = ({ characters }) => ({ characters });
+const mapStateToProps = state => ({ characters: state.get('characters') });
 
 export default connect(mapStateToProps)(Characters);

--- a/src/react/pages/lists/people.jsx
+++ b/src/react/pages/lists/people.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import ListWrapper from '../../utils/list-wrapper';
@@ -20,8 +20,8 @@ class People extends React.Component {
 
 };
 
-People.propTypes = { people: PropTypes.array.isRequired };
+People.propTypes = { people: ImmutablePropTypes.list.isRequired };
 
-const mapStateToProps = ({ people }) => ({ people });
+const mapStateToProps = state => ({ people: state.get('people') });
 
 export default connect(mapStateToProps)(People);

--- a/src/react/pages/lists/playtexts.jsx
+++ b/src/react/pages/lists/playtexts.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import ListWrapper from '../../utils/list-wrapper';
@@ -20,8 +20,8 @@ class Playtexts extends React.Component {
 
 };
 
-Playtexts.propTypes = { playtexts: PropTypes.array.isRequired };
+Playtexts.propTypes = { playtexts: ImmutablePropTypes.list.isRequired };
 
-const mapStateToProps = ({ playtexts }) => ({ playtexts });
+const mapStateToProps = state => ({ playtexts: state.get('playtexts') });
 
 export default connect(mapStateToProps)(Playtexts);

--- a/src/react/pages/lists/productions.jsx
+++ b/src/react/pages/lists/productions.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import ListWrapper from '../../utils/list-wrapper';
@@ -20,8 +20,8 @@ class Productions extends React.Component {
 
 };
 
-Productions.propTypes = { productions: PropTypes.array.isRequired };
+Productions.propTypes = { productions: ImmutablePropTypes.list.isRequired };
 
-const mapStateToProps = ({ productions }) => ({ productions });
+const mapStateToProps = state => ({ productions: state.get('productions') });
 
 export default connect(mapStateToProps)(Productions);

--- a/src/react/pages/lists/theatres.jsx
+++ b/src/react/pages/lists/theatres.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 
 import ListWrapper from '../../utils/list-wrapper';
@@ -20,8 +20,8 @@ class Theatres extends React.Component {
 
 };
 
-Theatres.propTypes = { theatres: PropTypes.array.isRequired };
+Theatres.propTypes = { theatres: ImmutablePropTypes.list.isRequired };
 
-const mapStateToProps = ({ theatres }) => ({ theatres });
+const mapStateToProps = state => ({ theatres: state.get('theatres') });
 
 export default connect(mapStateToProps)(Theatres);

--- a/src/react/utils/fetch-data-on-mount-wrapper.jsx
+++ b/src/react/utils/fetch-data-on-mount-wrapper.jsx
@@ -1,5 +1,5 @@
-import PropTypes from 'prop-types';
 import React from 'react';
+import ImmutablePropTypes from 'react-immutable-proptypes';
 import { connect } from 'react-redux';
 import { Helmet } from 'react-helmet';
 
@@ -36,7 +36,7 @@ class FetchDataOnMountWrapper extends React.Component {
 
 	shouldComponentUpdate (nextProps) {
 
-		return this.props.error.exists !== nextProps.error.exists;
+		return this.props.error.get('exists') !== nextProps.error.get('exists');
 
 	}
 
@@ -62,8 +62,8 @@ class FetchDataOnMountWrapper extends React.Component {
 				<main className="main-content">
 
 					{
-						error && error.exists
-							? <ErrorMessage errorText={error.message}/>
+						error.get('exists')
+							? <ErrorMessage errorText={error.get('message')}/>
 							: props.children
 					}
 
@@ -78,8 +78,8 @@ class FetchDataOnMountWrapper extends React.Component {
 
 };
 
-FetchDataOnMountWrapper.propTypes = { error: PropTypes.object.isRequired };
+FetchDataOnMountWrapper.propTypes = { error: ImmutablePropTypes.map.isRequired };
 
-const mapStateToProps = error => (error);
+const mapStateToProps = state => ({ error: state.get('error') });
 
 export default connect(mapStateToProps)(FetchDataOnMountWrapper);

--- a/src/react/utils/instance-wrapper.jsx
+++ b/src/react/utils/instance-wrapper.jsx
@@ -15,9 +15,9 @@ class InstanceWrapper extends React.Component {
 
 				<InstanceDocumentTitle instance={instance}/>
 
-				<ContentHeader text={instance.model}/>
+				<ContentHeader text={instance.get('model')}/>
 
-				<PageTitle text={instance.name}/>
+				<PageTitle text={instance.get('name')}/>
 
 				{children}
 

--- a/src/redux/actions/error.js
+++ b/src/redux/actions/error.js
@@ -7,7 +7,7 @@ const setError = error => createAction(SET_ERROR_STATUS, error);
 
 const resetError = () => (dispatch, getState) => {
 
-	if (getState().error.exists) {
+	if (getState().getIn(['error', 'exists'])) {
 
 		dispatch(createAction(RESET_ERROR_STATUS, { exists: false }));
 

--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -14,8 +14,8 @@ export default (model, uuid = null) => (dispatch, getState) => {
 		: false;
 
 	const apiCallReqd = instance
-		? getState()[model].uuid !== uuid
-		: !getState()[model].length;
+		? getState().getIn([model, 'uuid']) !== uuid
+		: !getState().get(model).size;
 
 	if (apiCallReqd) {
 

--- a/src/redux/reducers/character.js
+++ b/src/redux/reducers/character.js
@@ -1,6 +1,8 @@
+import { Map, fromJS } from 'immutable';
+
 import { REQUEST_CHARACTER, RECEIVE_CHARACTER } from '../utils/model-actions';
 
-const character = (state = {}, action) => {
+const character = (state = Map({}), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const character = (state = {}, action) => {
 			return state;
 
 		case RECEIVE_CHARACTER:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/characters.js
+++ b/src/redux/reducers/characters.js
@@ -1,6 +1,8 @@
+import { List, fromJS } from 'immutable';
+
 import { REQUEST_CHARACTERS, RECEIVE_CHARACTERS } from '../utils/model-actions';
 
-const characters = (state = [], action) => {
+const characters = (state = List([]), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const characters = (state = [], action) => {
 			return state;
 
 		case RECEIVE_CHARACTERS:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/error.js
+++ b/src/redux/reducers/error.js
@@ -1,14 +1,16 @@
+import { Map, fromJS } from 'immutable';
+
 import { SET_ERROR_STATUS, RESET_ERROR_STATUS } from '../actions/error';
 
-const error = (state = { exists: false }, action) => {
+const error = (state = Map({ exists: false }), action) => {
 
 	switch (action.type) {
 
 		case SET_ERROR_STATUS:
-			return action.payload;
+			return fromJS(action.payload);
 
 		case RESET_ERROR_STATUS:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/people.js
+++ b/src/redux/reducers/people.js
@@ -1,6 +1,8 @@
+import { List, fromJS } from 'immutable';
+
 import { REQUEST_PEOPLE, RECEIVE_PEOPLE } from '../utils/model-actions';
 
-const people = (state = [], action) => {
+const people = (state = List([]), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const people = (state = [], action) => {
 			return state;
 
 		case RECEIVE_PEOPLE:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/person.js
+++ b/src/redux/reducers/person.js
@@ -1,6 +1,8 @@
+import { Map, fromJS } from 'immutable';
+
 import { REQUEST_PERSON, RECEIVE_PERSON } from '../utils/model-actions';
 
-const person = (state = {}, action) => {
+const person = (state = Map({}), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const person = (state = {}, action) => {
 			return state;
 
 		case RECEIVE_PERSON:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/playtext.js
+++ b/src/redux/reducers/playtext.js
@@ -1,6 +1,8 @@
+import { Map, fromJS } from 'immutable';
+
 import { REQUEST_PLAYTEXT, RECEIVE_PLAYTEXT } from '../utils/model-actions';
 
-const playtext = (state = {}, action) => {
+const playtext = (state = Map({}), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const playtext = (state = {}, action) => {
 			return state;
 
 		case RECEIVE_PLAYTEXT:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/playtexts.js
+++ b/src/redux/reducers/playtexts.js
@@ -1,6 +1,8 @@
+import { List, fromJS } from 'immutable';
+
 import { REQUEST_PLAYTEXTS, RECEIVE_PLAYTEXTS } from '../utils/model-actions';
 
-const playtexts = (state = [], action) => {
+const playtexts = (state = List([]), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const playtexts = (state = [], action) => {
 			return state;
 
 		case RECEIVE_PLAYTEXTS:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/production.js
+++ b/src/redux/reducers/production.js
@@ -1,6 +1,8 @@
+import { Map, fromJS } from 'immutable';
+
 import { REQUEST_PRODUCTION, RECEIVE_PRODUCTION } from '../utils/model-actions';
 
-const production = (state = {}, action) => {
+const production = (state = Map({}), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const production = (state = {}, action) => {
 			return state;
 
 		case RECEIVE_PRODUCTION:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/productions.js
+++ b/src/redux/reducers/productions.js
@@ -1,6 +1,8 @@
+import { List, fromJS } from 'immutable';
+
 import { REQUEST_PRODUCTIONS, RECEIVE_PRODUCTIONS } from '../utils/model-actions';
 
-const productions = (state = [], action) => {
+const productions = (state = List([]), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const productions = (state = [], action) => {
 			return state;
 
 		case RECEIVE_PRODUCTIONS:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/theatre.js
+++ b/src/redux/reducers/theatre.js
@@ -1,6 +1,8 @@
+import { Map, fromJS } from 'immutable';
+
 import { REQUEST_THEATRE, RECEIVE_THEATRE } from '../utils/model-actions';
 
-const theatre = (state = {}, action) => {
+const theatre = (state = Map({}), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const theatre = (state = {}, action) => {
 			return state;
 
 		case RECEIVE_THEATRE:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/redux/reducers/theatres.js
+++ b/src/redux/reducers/theatres.js
@@ -1,6 +1,8 @@
+import { List, fromJS } from 'immutable';
+
 import { REQUEST_THEATRES, RECEIVE_THEATRES } from '../utils/model-actions';
 
-const theatres = (state = [], action) => {
+const theatres = (state = List([]), action) => {
 
 	switch (action.type) {
 
@@ -8,7 +10,7 @@ const theatres = (state = [], action) => {
 			return state;
 
 		case RECEIVE_THEATRES:
-			return action.payload;
+			return fromJS(action.payload);
 
 		default:
 			return state;

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -6,13 +6,15 @@
 import express from 'express';
 import favicon from 'serve-favicon';
 import http from 'http';
+import { fromJS } from 'immutable';
 import logger from 'morgan';
 import path from 'path';
 import session from 'express-session';
 
 import { Helmet } from 'react-helmet';
 import { matchPath } from 'react-router-dom';
-import { applyMiddleware, createStore, combineReducers } from 'redux';
+import { applyMiddleware, createStore } from 'redux';
+import { combineReducers } from 'redux-immutable';
 import thunkMiddleware from 'redux-thunk';
 
 import getReactHtml from '../react/react-html';
@@ -32,7 +34,7 @@ app.use(express.static('public'));
 
 const store = createStore(
 	combineReducers(reducers),
-	{},
+	fromJS({}),
 	applyMiddleware(...[thunkMiddleware])
 );
 


### PR DESCRIPTION
Uses Immutable.js so that Redux state is immutable, and when state is mapped to props of React components, that too is immutable.

To keep displaying the Redux logs (applied with `redux-logger`) in a readable format, `src/react/client-mount.jsx` now calls `createLogger()` with an argument: `createLogger({ stateTransformer: state => state.toJS() })`.

Admittedly, the app currently does not take advantage of any of the performance benefits of Immutable.js (e.g. state comparison in `componentDidUpdate()`), but feels easier to apply throughout while the app is not too large.

#### References:
- [Stack Overflow: mapStateToProps must return an object. Instead received Map {}?](https://stackoverflow.com/questions/35866005/mapstatetoprops-must-return-an-object-instead-received-map#answer-35878526).
- [Immutable.js documentation - DevDocs](https://devdocs.io/immutable).
- [Immutable.js](https://immutable-js.github.io/immutable-js/).
- [Immutable.js docs](https://immutable-js.github.io/immutable-js/docs).
- [Immutable.js docs: `List`](https://immutable-js.github.io/immutable-js/docs/#/List).
- [Immutable.js docs: `Map`](https://immutable-js.github.io/immutable-js/docs/#/Map).
- [Immutable.js docs: `fromJS`](https://immutable-js.github.io/immutable-js/docs/#/fromJS).
- [Immutable.js docs: `get()`](https://immutable-js.github.io/immutable-js/docs/#/get).
- [Immutable.js docs: `getIn()`](https://immutable-js.github.io/immutable-js/docs/#/getIn).

#### New dependencies:
- [npm: immutable](https://www.npmjs.com/package/immutable).
- [npm: react-immutable-proptypes](https://www.npmjs.com/package/react-immutable-proptypes).
- [npm: redux-immutable](https://www.npmjs.com/package/redux-immutable).