### PR TITLE
Use: async/await

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -8,7 +8,8 @@
     "fetch": false
   },
   "parserOptions": {
-      "sourceType": "module"
+      "sourceType": "module",
+      "ecmaVersion": 2017
   },
   "rules": {
     "eqeqeq": 2,

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "https://github.com/andygout",
   "license": "MS-RSL",
   "dependencies": {
+    "core-js": "^3.1.4",
     "express": "^4.14.0",
     "express-session": "^1.14.1",
     "immutable": "^4.0.0-rc.12",
@@ -32,6 +33,7 @@
     "redux-immutable": "^4.0.0",
     "redux-logger": "^3.0.6",
     "redux-thunk": "^2.2.0",
+    "regenerator-runtime": "^0.13.2",
     "serve-favicon": "^2.2.0"
   },
   "devDependencies": {

--- a/src/redux/actions/model.js
+++ b/src/redux/actions/model.js
@@ -7,7 +7,7 @@ const request = model => createAction(actions[`REQUEST_${model.toUpperCase()}`])
 
 const receive = (instance, model) => createAction(actions[`RECEIVE_${model.toUpperCase()}`], instance);
 
-export default (model, uuid = null) => (dispatch, getState) => {
+export default (model, uuid = null) => async (dispatch, getState) => {
 
 	const instance = uuid
 		? true
@@ -29,16 +29,21 @@ export default (model, uuid = null) => (dispatch, getState) => {
 
 		if (instance) url += `/${uuid}`;
 
-		return fetch(url, { 'mode': 'cors' })
-			.then(response => {
+		try {
 
-				if (response.status !== 200) throw new Error(response.statusText);
+			const response = await fetch(url, { 'mode': 'cors' });
 
-				return response.json();
+			if (response.status !== 200) throw new Error(response.statusText);
 
-			})
-			.then(instance => dispatch(receive(instance, model)))
-			.catch(({ message }) => dispatch(setError({ exists: true, message })));
+			const instance = await response.json();
+
+			dispatch(receive(instance, model));
+
+		} catch ({ message }) {
+
+			dispatch(setError({ exists: true, message }));
+
+		}
 
 	}
 

--- a/src/server/app.js
+++ b/src/server/app.js
@@ -3,6 +3,9 @@
 	no-unused-vars: ["error", { "argsIgnorePattern": "next" }]
 */
 
+import 'core-js/stable';
+import 'regenerator-runtime/runtime';
+
 import express from 'express';
 import favicon from 'serve-favicon';
 import http from 'http';
@@ -38,7 +41,7 @@ const store = createStore(
 	applyMiddleware(...[thunkMiddleware])
 );
 
-app.get('*', (req, res) => {
+app.get('*', async (req, res) => {
 
 	const { dispatch, getState } = store;
 
@@ -54,42 +57,40 @@ app.get('*', (req, res) => {
 
 	});
 
-	Promise.all(fetchDataPromises).then(() => {
+	await Promise.all(fetchDataPromises);
 
-		const preloadedState = getState();
+	const preloadedState = getState();
 
-		const reactHtml = getReactHtml(req, store);
+	const reactHtml = getReactHtml(req, store);
 
-		const head = Helmet.rewind();
+	const head = Helmet.rewind();
 
-		const html = `
-			<!DOCTYPE html>
+	const html = `
+		<!DOCTYPE html>
 
-			<html lang="en-GB">
+		<html lang="en-GB">
 
-				<head>
-					${head.title.toString()}
-					<link rel="stylesheet" href="/main.css">
-					<script src="/main.js"></script>
-					<meta charset="utf-8">
-				</head>
+			<head>
+				${head.title.toString()}
+				<link rel="stylesheet" href="/main.css">
+				<script src="/main.js"></script>
+				<meta charset="utf-8">
+			</head>
 
-				<script id="react-client-data" type="text/json">
-					${JSON.stringify(preloadedState)}
-				</script>
+			<script id="react-client-data" type="text/json">
+				${JSON.stringify(preloadedState)}
+			</script>
 
-				<div id="app" class="app">
-					${reactHtml}
-				</div>
+			<div id="app" class="app">
+				${reactHtml}
+			</div>
 
-			</html>
-		`.split('\n').map(line => line.trim()).join('');
+		</html>
+	`.split('\n').map(line => line.trim()).join('');
 
-		res.write(html);
+	res.write(html);
 
-		res.end();
-
-	});
+	res.end();
 
 });
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -72,7 +72,17 @@ const clientConfig = {
 				test: /\.(js|jsx)$/,
 				loader: 'babel-loader',
 				query: {
-					presets: ['@babel/preset-env', '@babel/preset-react']
+					presets: [
+						[
+							"@babel/preset-env",
+							{
+								"targets": {
+									"node": "10"
+								}
+							}
+						],
+						'@babel/preset-react'
+					]
 				}
 			}
 		]


### PR DESCRIPTION
Applies ES2017 (ES8) `async/await` syntax for promise handling.

#### References:
- [Stack Overflow: Babel 6 regeneratorRuntime is not defined](https://stackoverflow.com/questions/33527653/babel-6-regeneratorruntime-is-not-defined#answer-33527883): "`babel-polyfill` is required".
- [Babel: @babel/polyfill](https://babeljs.io/docs/en/babel-polyfill): "As of Babel 7.4.0, this package has been deprecated in favor of directly including `core-js/stable` (to polyfill ECMAScript features) and `regenerator-runtime/runtime` (needed to use transpiled generator functions)".
- [GitHub: esline/eslint: Issues: Error with async: "Parsing error: Unexpected token =>"](https://github.com/eslint/eslint/issues/8126#issuecomment-281559970): "you should use `ecmaVersion: 8` or `ecmaVersion: 2017` in your config".
- [Medium: Enabling Async/Await and Generator Functions in Babel and Node JS by Binyamin](https://medium.com/@binyamin/enabling-async-await-and-generator-functions-in-babel-node-and-express-71e941b183e2): `.babelrc` changes required to prevent `Uncaught ReferenceError: regeneratorRuntime is not defined`.

#### New dependencies:
- [npm: core-js](https://www.npmjs.com/package/core-js).
- [npm: regenerator-runtime](https://www.npmjs.com/package/regenerator-runtime).